### PR TITLE
Support more comment types

### DIFF
--- a/XmlDocCollapser/Properties/AssemblyInfo.cs
+++ b/XmlDocCollapser/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/XmlDocCollapser/XmlDocCollapser.csproj
+++ b/XmlDocCollapser/XmlDocCollapser.csproj
@@ -73,9 +73,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.VisualStudio.Threading.Analyzers.15.6.46\analyzers\cs\Microsoft.VisualStudio.Threading.Analyzers.dll" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.CoreUtility">
       <Version>17.0.487</Version>
     </PackageReference>

--- a/XmlDocCollapser/source.extension.vsixmanifest
+++ b/XmlDocCollapser/source.extension.vsixmanifest
@@ -1,12 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="XmlDocCollapser.8b837323-73f8-4014-b91c-760258a6f0bc" Version="1.0" Language="en-US" Publisher="Michał Delura" />
+        <Identity Id="XmlDocCollapser.8b837323-73f8-4014-b91c-760258a6f0bc" Version="1.1" Language="en-US" Publisher="Michał Delura" />
         <DisplayName>XmlDocCollapser</DisplayName>
         <Description xml:space="preserve">The extension automatically collapses XML Docs when the file is opened.</Description>
+        <Preview>true</Preview>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.10]">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Support for:
- Block style comments `/** */`
- Comments that start with element other than Summary

Updating to latest extension practices wouldn't hurt, but seems it to work as-is.